### PR TITLE
Add file path lookup API

### DIFF
--- a/src/main/java/net/ubn/td/controller/FileIdResponse.java
+++ b/src/main/java/net/ubn/td/controller/FileIdResponse.java
@@ -1,0 +1,19 @@
+package net.ubn.td.controller;
+
+public class FileIdResponse {
+    private String fileId;
+
+    public FileIdResponse() {}
+
+    public FileIdResponse(String fileId) {
+        this.fileId = fileId;
+    }
+
+    public String getFileId() {
+        return fileId;
+    }
+
+    public void setFileId(String fileId) {
+        this.fileId = fileId;
+    }
+}

--- a/src/main/java/net/ubn/td/controller/FileQueryController.java
+++ b/src/main/java/net/ubn/td/controller/FileQueryController.java
@@ -1,0 +1,34 @@
+package net.ubn.td.controller;
+
+import net.ubn.td.exceptions.ApiReturn;
+import net.ubn.td.exceptions.ResponseCode;
+import net.ubn.td.service.FileRecordService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/files")
+public class FileQueryController {
+
+    private final FileRecordService recordService;
+
+    public FileQueryController(FileRecordService recordService) {
+        this.recordService = recordService;
+    }
+
+    @GetMapping("/lookup")
+    public ResponseEntity<ApiReturn<FileIdResponse>> getFileId(@RequestParam("path") String path) {
+        String fileId = recordService.getFileIdByPath(path);
+        if (fileId == null) {
+            return ResponseEntity.notFound().build();
+        }
+        ApiReturn<FileIdResponse> api = new ApiReturn<>();
+        api.setCode(ResponseCode.M000);
+        api.setMessage("success");
+        api.setData(new FileIdResponse(fileId));
+        return ResponseEntity.ok(api);
+    }
+}

--- a/src/main/java/net/ubn/td/repository/FileRecordRepository.java
+++ b/src/main/java/net/ubn/td/repository/FileRecordRepository.java
@@ -5,5 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
+import java.util.Optional;
+
 public interface FileRecordRepository extends JpaRepository<FileRecord, UUID> {
+    Optional<FileRecord> findByDirAndStoredFilename(String dir, String storedFilename);
 }

--- a/src/main/java/net/ubn/td/service/FileRecordService.java
+++ b/src/main/java/net/ubn/td/service/FileRecordService.java
@@ -1,0 +1,5 @@
+package net.ubn.td.service;
+
+public interface FileRecordService {
+    String getFileIdByPath(String path);
+}

--- a/src/main/java/net/ubn/td/service/FileRecordServiceImpl.java
+++ b/src/main/java/net/ubn/td/service/FileRecordServiceImpl.java
@@ -1,0 +1,31 @@
+package net.ubn.td.service;
+
+import net.ubn.td.entity.FileRecord;
+import net.ubn.td.repository.FileRecordRepository;
+import org.springframework.stereotype.Service;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@Service
+public class FileRecordServiceImpl implements FileRecordService {
+
+    private final FileRecordRepository repository;
+
+    public FileRecordServiceImpl(FileRecordRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public String getFileIdByPath(String path) {
+        if (path.startsWith("/")) {
+            path = path.substring(1);
+        }
+        Path p = Paths.get(path);
+        String filename = p.getFileName().toString();
+        String dir = p.getParent() == null ? "" : p.getParent().toString();
+        return repository.findByDirAndStoredFilename(dir, filename)
+                .map(FileRecord::getFileId)
+                .orElse(null);
+    }
+}

--- a/src/test/java/net/ubn/td/controller/FileQueryControllerTest.java
+++ b/src/test/java/net/ubn/td/controller/FileQueryControllerTest.java
@@ -1,0 +1,58 @@
+package net.ubn.td.controller;
+
+import net.ubn.td.entity.FileRecord;
+import net.ubn.td.repository.FileRecordRepository;
+import net.ubn.td.util.UuidV7Generator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.util.FileSystemUtils;
+
+import java.nio.file.Paths;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = "file.upload-dir=uploads-test")
+class FileQueryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private FileRecordRepository repository;
+
+    @AfterEach
+    void cleanup() throws Exception {
+        FileSystemUtils.deleteRecursively(Paths.get("uploads-test"));
+        repository.deleteAll();
+    }
+
+    @Test
+    void lookupFound() throws Exception {
+        FileRecord record = new FileRecord();
+        record.setId(UuidV7Generator.generate());
+        record.setFileId("abc123");
+        record.setDir("uploads-test");
+        record.setStoredFilename("test.mp3");
+        repository.save(record);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/files/lookup")
+                        .param("path", "/uploads-test/test.mp3"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.fileId").value("abc123"));
+    }
+
+    @Test
+    void lookupNotFound() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/files/lookup")
+                        .param("path", "/uploads-test/none.mp3"))
+                .andExpect(status().isNotFound());
+    }
+}


### PR DESCRIPTION
## Summary
- add repository method to query by directory and filename
- create service for file path lookup
- implement controller to return fileId for a given path
- provide response POJO for fileId
- add unit tests for lookup API

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850ed06b6b4832db8be57fa57dbfd5f