### PR TITLE
Implement package task creation API

### DIFF
--- a/src/main/java/net/ubn/td/controller/PackageTaskController.java
+++ b/src/main/java/net/ubn/td/controller/PackageTaskController.java
@@ -1,0 +1,32 @@
+package net.ubn.td.controller;
+
+import net.ubn.td.exceptions.ApiReturn;
+import net.ubn.td.exceptions.ResponseCode;
+import net.ubn.td.service.PackageTaskService;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/package")
+public class PackageTaskController {
+
+    private final PackageTaskService taskService;
+
+    public PackageTaskController(PackageTaskService taskService) {
+        this.taskService = taskService;
+    }
+
+    @PostMapping(value = "/task", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ApiReturn<TaskIdResponse>> createTask(@RequestBody PackageTaskRequest request) {
+        String id = taskService.createTask(request.getFileId(), request.getPackageType());
+        ApiReturn<TaskIdResponse> api = new ApiReturn<>();
+        api.setCode(ResponseCode.M000);
+        api.setMessage("success");
+        api.setData(new TaskIdResponse(id));
+        return ResponseEntity.ok(api);
+    }
+}

--- a/src/main/java/net/ubn/td/controller/PackageTaskRequest.java
+++ b/src/main/java/net/ubn/td/controller/PackageTaskRequest.java
@@ -1,0 +1,11 @@
+package net.ubn.td.controller;
+
+public class PackageTaskRequest {
+    private String fileId;
+    private String packageType;
+
+    public String getFileId() { return fileId; }
+    public void setFileId(String fileId) { this.fileId = fileId; }
+    public String getPackageType() { return packageType; }
+    public void setPackageType(String packageType) { this.packageType = packageType; }
+}

--- a/src/main/java/net/ubn/td/controller/TaskIdResponse.java
+++ b/src/main/java/net/ubn/td/controller/TaskIdResponse.java
@@ -1,0 +1,13 @@
+package net.ubn.td.controller;
+
+public class TaskIdResponse {
+    private String taskId;
+
+    public TaskIdResponse() {}
+    public TaskIdResponse(String taskId) {
+        this.taskId = taskId;
+    }
+
+    public String getTaskId() { return taskId; }
+    public void setTaskId(String taskId) { this.taskId = taskId; }
+}

--- a/src/main/java/net/ubn/td/entity/PackageTask.java
+++ b/src/main/java/net/ubn/td/entity/PackageTask.java
@@ -1,0 +1,24 @@
+package net.ubn.td.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+import java.util.UUID;
+
+@Entity
+public class PackageTask {
+    @Id
+    private UUID id;
+    private String fileId;
+    private String packageType;
+    private String status;
+
+    public UUID getId() { return id; }
+    public void setId(UUID id) { this.id = id; }
+    public String getFileId() { return fileId; }
+    public void setFileId(String fileId) { this.fileId = fileId; }
+    public String getPackageType() { return packageType; }
+    public void setPackageType(String packageType) { this.packageType = packageType; }
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+}

--- a/src/main/java/net/ubn/td/repository/PackageTaskRepository.java
+++ b/src/main/java/net/ubn/td/repository/PackageTaskRepository.java
@@ -1,0 +1,9 @@
+package net.ubn.td.repository;
+
+import net.ubn.td.entity.PackageTask;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface PackageTaskRepository extends JpaRepository<PackageTask, UUID> {
+}

--- a/src/main/java/net/ubn/td/service/PackageTaskService.java
+++ b/src/main/java/net/ubn/td/service/PackageTaskService.java
@@ -1,0 +1,5 @@
+package net.ubn.td.service;
+
+public interface PackageTaskService {
+    String createTask(String fileId, String packageType);
+}

--- a/src/main/java/net/ubn/td/service/PackageTaskServiceImpl.java
+++ b/src/main/java/net/ubn/td/service/PackageTaskServiceImpl.java
@@ -1,0 +1,27 @@
+package net.ubn.td.service;
+
+import net.ubn.td.entity.PackageTask;
+import net.ubn.td.repository.PackageTaskRepository;
+import net.ubn.td.util.UuidV7Generator;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PackageTaskServiceImpl implements PackageTaskService {
+
+    private final PackageTaskRepository repository;
+
+    public PackageTaskServiceImpl(PackageTaskRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public String createTask(String fileId, String packageType) {
+        PackageTask task = new PackageTask();
+        task.setId(UuidV7Generator.generate());
+        task.setFileId(fileId);
+        task.setPackageType(packageType);
+        task.setStatus("initial");
+        repository.save(task);
+        return task.getId().toString();
+    }
+}

--- a/src/test/java/net/ubn/td/controller/PackageTaskControllerTest.java
+++ b/src/test/java/net/ubn/td/controller/PackageTaskControllerTest.java
@@ -1,0 +1,40 @@
+package net.ubn.td.controller;
+
+import net.ubn.td.repository.PackageTaskRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.http.MediaType;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class PackageTaskControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private PackageTaskRepository repository;
+
+    @AfterEach
+    void cleanup() {
+        repository.deleteAll();
+    }
+
+    @Test
+    void createTaskSuccess() throws Exception {
+        String json = "{\"fileId\":\"abc\",\"packageType\":\"lcp\"}";
+        mockMvc.perform(MockMvcRequestBuilders.post("/package/task")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("M000"))
+                .andExpect(jsonPath("$.data.taskId").exists());
+    }
+}


### PR DESCRIPTION
## Summary
- add endpoint `/package/task` for submitting packaging tasks
- store new task with status `initial` and return task ID
- provide service/repository/entity to persist package tasks
- test that POST `/package/task` returns the taskId

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68510245dea8832d94ea622f3fa937f9