### PR TITLE
Add scheduled job for package tasks

### DIFF
--- a/src/main/java/net/ubn/td/PackageWebApplication.java
+++ b/src/main/java/net/ubn/td/PackageWebApplication.java
@@ -2,9 +2,11 @@ package net.ubn.td;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 //import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 
 @SpringBootApplication
+@EnableScheduling
 //@EnableDiscoveryClient
 public class PackageWebApplication {
     public static void main(String[] args) {

--- a/src/main/java/net/ubn/td/entity/PackageTask.java
+++ b/src/main/java/net/ubn/td/entity/PackageTask.java
@@ -12,6 +12,7 @@ public class PackageTask {
     private String fileId;
     private String packageType;
     private String status;
+    private String errorMessage;
 
     public UUID getId() { return id; }
     public void setId(UUID id) { this.id = id; }
@@ -21,4 +22,6 @@ public class PackageTask {
     public void setPackageType(String packageType) { this.packageType = packageType; }
     public String getStatus() { return status; }
     public void setStatus(String status) { this.status = status; }
+    public String getErrorMessage() { return errorMessage; }
+    public void setErrorMessage(String errorMessage) { this.errorMessage = errorMessage; }
 }

--- a/src/main/java/net/ubn/td/repository/PackageTaskRepository.java
+++ b/src/main/java/net/ubn/td/repository/PackageTaskRepository.java
@@ -4,6 +4,8 @@ import net.ubn.td.entity.PackageTask;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
+import java.util.List;
 
 public interface PackageTaskRepository extends JpaRepository<PackageTask, UUID> {
+    List<PackageTask> findByStatus(String status);
 }

--- a/src/main/java/net/ubn/td/service/PackageJobService.java
+++ b/src/main/java/net/ubn/td/service/PackageJobService.java
@@ -1,0 +1,49 @@
+package net.ubn.td.service;
+
+import net.ubn.td.entity.PackageTask;
+import net.ubn.td.repository.PackageTaskRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class PackageJobService {
+
+    private final PackageTaskRepository repository;
+
+    public PackageJobService(PackageTaskRepository repository) {
+        this.repository = repository;
+    }
+
+    @Scheduled(fixedDelay = 60000)
+    public void scanTasks() {
+        List<PackageTask> tasks = repository.findByStatus("initial");
+        tasks.forEach(this::processTask);
+    }
+
+    void processTask(PackageTask task) {
+        try {
+            task.setStatus("processing");
+            repository.save(task);
+            if ("LCP".equalsIgnoreCase(task.getPackageType())) {
+                doLcpPackage(task);
+            } else {
+                doHlsPackage(task);
+            }
+            task.setStatus("done");
+        } catch (Exception e) {
+            task.setStatus("failed");
+            task.setErrorMessage(e.getMessage());
+        }
+        repository.save(task);
+    }
+
+    protected void doLcpPackage(PackageTask task) {
+        // placeholder for real LCP packaging logic
+    }
+
+    protected void doHlsPackage(PackageTask task) {
+        // placeholder for real HLS packaging logic
+    }
+}

--- a/src/test/java/net/ubn/td/PackageJobServiceTest.java
+++ b/src/test/java/net/ubn/td/PackageJobServiceTest.java
@@ -1,0 +1,53 @@
+package net.ubn.td;
+
+import net.ubn.td.entity.PackageTask;
+import net.ubn.td.repository.PackageTaskRepository;
+import net.ubn.td.service.PackageJobService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PackageJobServiceTest {
+
+    @Mock
+    PackageTaskRepository repository;
+
+    @InjectMocks
+    PackageJobService service;
+
+    @Test
+    void processTaskSuccess() {
+        PackageTask task = new PackageTask();
+        task.setPackageType("HLS");
+        task.setStatus("initial");
+
+        PackageJobService spy = spy(service);
+        doNothing().when(spy).doHlsPackage(any());
+
+        spy.processTask(task);
+
+        assertEquals("done", task.getStatus());
+        assertNull(task.getErrorMessage());
+    }
+
+    @Test
+    void processTaskError() {
+        PackageTask task = new PackageTask();
+        task.setPackageType("LCP");
+        task.setStatus("initial");
+
+        PackageJobService spy = spy(service);
+        doThrow(new RuntimeException("boom")).when(spy).doLcpPackage(any());
+
+        spy.processTask(task);
+
+        assertEquals("failed", task.getStatus());
+        assertEquals("boom", task.getErrorMessage());
+    }
+}


### PR DESCRIPTION
## Summary
- add `errorMessage` to `PackageTask`
- extend `PackageTaskRepository` with `findByStatus`
- implement `PackageJobService` with `@Scheduled` task
- enable scheduling in the application
- add unit tests for task processing success and failure

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68510d79051c832d84b16f86cce4c415