### PR TITLE
Implement watermark task API

### DIFF
--- a/src/main/java/net/ubn/td/controller/WatermarkTaskController.java
+++ b/src/main/java/net/ubn/td/controller/WatermarkTaskController.java
@@ -1,0 +1,32 @@
+package net.ubn.td.controller;
+
+import net.ubn.td.exceptions.ApiReturn;
+import net.ubn.td.exceptions.ResponseCode;
+import net.ubn.td.service.WatermarkTaskService;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/watermark")
+public class WatermarkTaskController {
+
+    private final WatermarkTaskService service;
+
+    public WatermarkTaskController(WatermarkTaskService service) {
+        this.service = service;
+    }
+
+    @PostMapping(value = "/task", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ApiReturn<TaskIdResponse>> createTask(@RequestBody WatermarkTaskRequest request) {
+        String id = service.createTask(request.getFileId(), request.getText());
+        ApiReturn<TaskIdResponse> api = new ApiReturn<>();
+        api.setCode(ResponseCode.M000);
+        api.setMessage("success");
+        api.setData(new TaskIdResponse(id));
+        return ResponseEntity.ok(api);
+    }
+}

--- a/src/main/java/net/ubn/td/controller/WatermarkTaskRequest.java
+++ b/src/main/java/net/ubn/td/controller/WatermarkTaskRequest.java
@@ -1,0 +1,11 @@
+package net.ubn.td.controller;
+
+public class WatermarkTaskRequest {
+    private String fileId;
+    private String text;
+
+    public String getFileId() { return fileId; }
+    public void setFileId(String fileId) { this.fileId = fileId; }
+    public String getText() { return text; }
+    public void setText(String text) { this.text = text; }
+}

--- a/src/main/java/net/ubn/td/entity/WatermarkTask.java
+++ b/src/main/java/net/ubn/td/entity/WatermarkTask.java
@@ -1,0 +1,37 @@
+package net.ubn.td.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+public class WatermarkTask {
+    @Id
+    private UUID id;
+    private String fileId;
+    private String text;
+    private String status;
+    private LocalDateTime modificationDate;
+    private int retryCount;
+    private String errorMessage;
+    private String outputFileId;
+
+    public UUID getId() { return id; }
+    public void setId(UUID id) { this.id = id; }
+    public String getFileId() { return fileId; }
+    public void setFileId(String fileId) { this.fileId = fileId; }
+    public String getText() { return text; }
+    public void setText(String text) { this.text = text; }
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+    public LocalDateTime getModificationDate() { return modificationDate; }
+    public void setModificationDate(LocalDateTime modificationDate) { this.modificationDate = modificationDate; }
+    public int getRetryCount() { return retryCount; }
+    public void setRetryCount(int retryCount) { this.retryCount = retryCount; }
+    public String getErrorMessage() { return errorMessage; }
+    public void setErrorMessage(String errorMessage) { this.errorMessage = errorMessage; }
+    public String getOutputFileId() { return outputFileId; }
+    public void setOutputFileId(String outputFileId) { this.outputFileId = outputFileId; }
+}

--- a/src/main/java/net/ubn/td/repository/FileRecordRepository.java
+++ b/src/main/java/net/ubn/td/repository/FileRecordRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 
 public interface FileRecordRepository extends JpaRepository<FileRecord, UUID> {
     Optional<FileRecord> findByDirAndStoredFilename(String dir, String storedFilename);
+    Optional<FileRecord> findByFileId(String fileId);
 }

--- a/src/main/java/net/ubn/td/repository/WatermarkTaskRepository.java
+++ b/src/main/java/net/ubn/td/repository/WatermarkTaskRepository.java
@@ -1,0 +1,13 @@
+package net.ubn.td.repository;
+
+import net.ubn.td.entity.WatermarkTask;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public interface WatermarkTaskRepository extends JpaRepository<WatermarkTask, UUID> {
+    List<WatermarkTask> findByStatus(String status);
+    List<WatermarkTask> findByStatusAndModificationDateBefore(String status, LocalDateTime date);
+}

--- a/src/main/java/net/ubn/td/service/WatermarkJobService.java
+++ b/src/main/java/net/ubn/td/service/WatermarkJobService.java
@@ -1,0 +1,84 @@
+package net.ubn.td.service;
+
+import net.ubn.td.entity.FileRecord;
+import net.ubn.td.entity.WatermarkTask;
+import net.ubn.td.repository.FileRecordRepository;
+import net.ubn.td.repository.WatermarkTaskRepository;
+import net.ubn.td.util.UuidV7Generator;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.util.DigestUtils;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class WatermarkJobService {
+
+    private final WatermarkTaskRepository repository;
+    private final FileRecordRepository fileRepository;
+    private final WatermarkProcessor processor;
+    private static final int MAX_RETRIES = 3;
+
+    public WatermarkJobService(WatermarkTaskRepository repository,
+                               FileRecordRepository fileRepository,
+                               WatermarkProcessor processor) {
+        this.repository = repository;
+        this.fileRepository = fileRepository;
+        this.processor = processor;
+    }
+
+    @Scheduled(fixedDelay = 60000)
+    public void scanTasks() {
+        List<WatermarkTask> tasks = repository.findByStatus("initial");
+        tasks.forEach(this::processTask);
+    }
+
+    @Scheduled(fixedDelay = 300000)
+    public void scanProcessingTasks() {
+        LocalDateTime threshold = LocalDateTime.now().minusHours(1);
+        List<WatermarkTask> tasks = repository.findByStatusAndModificationDateBefore("processing", threshold);
+        tasks.forEach(task -> {
+            if (task.getRetryCount() < MAX_RETRIES) {
+                task.setRetryCount(task.getRetryCount() + 1);
+                processTask(task);
+            } else {
+                task.setStatus("failed");
+                repository.save(task);
+            }
+        });
+    }
+
+    void processTask(WatermarkTask task) {
+        try {
+            task.setStatus("processing");
+            task.setModificationDate(LocalDateTime.now());
+            repository.save(task);
+
+            FileRecord record = fileRepository.findByFileId(task.getFileId())
+                    .orElseThrow(() -> new RuntimeException("file not found"));
+            Path input = Paths.get(record.getDir()).resolve(record.getStoredFilename());
+            Path output = processor.applyWatermark(input, task.getText());
+            byte[] bytes = Files.readAllBytes(output);
+
+            FileRecord outRec = new FileRecord();
+            outRec.setId(UuidV7Generator.generate());
+            outRec.setFileId(DigestUtils.md5DigestAsHex(bytes));
+            outRec.setDir(output.getParent().toString());
+            outRec.setStoredFilename(output.getFileName().toString());
+            outRec.setOriginalFilename(record.getOriginalFilename());
+            fileRepository.save(outRec);
+
+            task.setOutputFileId(outRec.getFileId());
+            task.setStatus("done");
+        } catch (Exception e) {
+            task.setStatus("failed");
+            task.setErrorMessage(e.getMessage());
+        }
+        task.setModificationDate(LocalDateTime.now());
+        repository.save(task);
+    }
+}

--- a/src/main/java/net/ubn/td/service/WatermarkProcessor.java
+++ b/src/main/java/net/ubn/td/service/WatermarkProcessor.java
@@ -1,0 +1,8 @@
+package net.ubn.td.service;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+public interface WatermarkProcessor {
+    Path applyWatermark(Path input, String text) throws IOException;
+}

--- a/src/main/java/net/ubn/td/service/WatermarkProcessorImpl.java
+++ b/src/main/java/net/ubn/td/service/WatermarkProcessorImpl.java
@@ -1,0 +1,48 @@
+package net.ubn.td.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Service
+public class WatermarkProcessorImpl implements WatermarkProcessor {
+
+    @Value("${file.upload-dir}")
+    private String uploadDir;
+
+    @Override
+    public Path applyWatermark(Path input, String text) throws IOException {
+        String ext = StringUtils.getFilenameExtension(input.getFileName().toString());
+        Path outDir = Paths.get(uploadDir, "watermarked");
+        Files.createDirectories(outDir);
+        String timestamp = DateTimeFormatter.ofPattern("yyyyMMddHHmmss").format(LocalDateTime.now());
+        Path output = ext == null ? outDir.resolve(timestamp) : outDir.resolve(timestamp + "." + ext);
+
+        if (ext != null && (ext.equalsIgnoreCase("jpg") || ext.equalsIgnoreCase("jpeg") || ext.equalsIgnoreCase("png"))) {
+            BufferedImage image = ImageIO.read(input.toFile());
+            Graphics2D g2d = image.createGraphics();
+            g2d.setFont(new Font("Arial", Font.BOLD, 36));
+            g2d.setColor(new Color(255, 0, 0, 128));
+            FontMetrics fm = g2d.getFontMetrics();
+            int x = image.getWidth() - fm.stringWidth(text) - 10;
+            int y = image.getHeight() - fm.getHeight();
+            g2d.drawString(text, x, y);
+            g2d.dispose();
+            ImageIO.write(image, ext, output.toFile());
+        } else {
+            // For video or other types, simply copy the file
+            Files.copy(input, output);
+        }
+        return output;
+    }
+}

--- a/src/main/java/net/ubn/td/service/WatermarkTaskService.java
+++ b/src/main/java/net/ubn/td/service/WatermarkTaskService.java
@@ -1,0 +1,5 @@
+package net.ubn.td.service;
+
+public interface WatermarkTaskService {
+    String createTask(String fileId, String text);
+}

--- a/src/main/java/net/ubn/td/service/WatermarkTaskServiceImpl.java
+++ b/src/main/java/net/ubn/td/service/WatermarkTaskServiceImpl.java
@@ -1,0 +1,31 @@
+package net.ubn.td.service;
+
+import net.ubn.td.entity.WatermarkTask;
+import net.ubn.td.repository.WatermarkTaskRepository;
+import net.ubn.td.util.UuidV7Generator;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+public class WatermarkTaskServiceImpl implements WatermarkTaskService {
+
+    private final WatermarkTaskRepository repository;
+
+    public WatermarkTaskServiceImpl(WatermarkTaskRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public String createTask(String fileId, String text) {
+        WatermarkTask task = new WatermarkTask();
+        task.setId(UuidV7Generator.generate());
+        task.setFileId(fileId);
+        task.setText(text);
+        task.setStatus("initial");
+        task.setRetryCount(0);
+        task.setModificationDate(LocalDateTime.now());
+        repository.save(task);
+        return task.getId().toString();
+    }
+}

--- a/src/test/java/net/ubn/td/WatermarkJobServiceTest.java
+++ b/src/test/java/net/ubn/td/WatermarkJobServiceTest.java
@@ -1,0 +1,75 @@
+package net.ubn.td;
+
+import net.ubn.td.entity.FileRecord;
+import net.ubn.td.entity.WatermarkTask;
+import net.ubn.td.repository.FileRecordRepository;
+import net.ubn.td.repository.WatermarkTaskRepository;
+import net.ubn.td.service.WatermarkJobService;
+import net.ubn.td.service.WatermarkProcessor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class WatermarkJobServiceTest {
+
+    @Mock
+    WatermarkTaskRepository taskRepository;
+    @Mock
+    FileRecordRepository fileRepository;
+    @Mock
+    WatermarkProcessor processor;
+
+    @InjectMocks
+    WatermarkJobService service;
+
+    @Test
+    void processTaskSuccess() throws Exception {
+        Path tempIn = Files.createTempFile("in", ".png");
+        Files.writeString(tempIn, "abc");
+        Path tempOut = Files.createTempFile("out", ".png");
+        Files.writeString(tempOut, "def");
+
+        FileRecord rec = new FileRecord();
+        rec.setDir(tempIn.getParent().toString());
+        rec.setStoredFilename(tempIn.getFileName().toString());
+        rec.setOriginalFilename("test.png");
+
+        WatermarkTask task = new WatermarkTask();
+        task.setFileId("fid");
+        task.setText("txt");
+
+        when(fileRepository.findByFileId("fid")).thenReturn(Optional.of(rec));
+        when(processor.applyWatermark(any(), eq("txt"))).thenReturn(tempOut);
+
+        service.processTask(task);
+
+        assertEquals("done", task.getStatus());
+        assertNotNull(task.getOutputFileId());
+        assertNull(task.getErrorMessage());
+    }
+
+    @Test
+    void processTaskError() throws Exception {
+        WatermarkTask task = new WatermarkTask();
+        task.setFileId("fid");
+        task.setText("txt");
+
+        when(fileRepository.findByFileId("fid")).thenThrow(new RuntimeException("boom"));
+
+        service.processTask(task);
+
+        assertEquals("failed", task.getStatus());
+        assertEquals("boom", task.getErrorMessage());
+    }
+}

--- a/src/test/java/net/ubn/td/controller/WatermarkTaskControllerTest.java
+++ b/src/test/java/net/ubn/td/controller/WatermarkTaskControllerTest.java
@@ -1,0 +1,42 @@
+package net.ubn.td.controller;
+
+import net.ubn.td.repository.WatermarkTaskRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = "file.upload-dir=uploads-test")
+class WatermarkTaskControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WatermarkTaskRepository repository;
+
+    @AfterEach
+    void cleanup() {
+        repository.deleteAll();
+    }
+
+    @Test
+    void createTaskSuccess() throws Exception {
+        String json = "{\"fileId\":\"abc\",\"text\":\"hello\"}";
+        mockMvc.perform(MockMvcRequestBuilders.post("/watermark/task")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("M000"))
+                .andExpect(jsonPath("$.data.taskId").exists());
+    }
+}


### PR DESCRIPTION
## Summary
- add watermark task API for uploading watermarks asynchronously
- process watermark tasks with scheduled job service
- implement watermarking for images (overlay text) and copying for other types
- provide repository and service layers for watermark tasks
- include controller and service unit tests

## Testing
- `mvn -q -DskipTests=false test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685113866d1c832da1fa290fa29284d6